### PR TITLE
CIWEMB-23: Add support for 'Campaign Manger' extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Shoreditch for third-party extensions
+
+This extension provides Shoreditch compatibility fixes for third-party CiviCRM extensions, at the moment it supports
+the following extensions:
+
+- Campaign Manger: https://civicrm.org/extensions/campaign-manager

--- a/css/shoreditchforthirdparty.css
+++ b/css/shoreditchforthirdparty.css
@@ -1,0 +1,55 @@
+/** "Campaign Manger" extension style fixes: https://civicrm.org/extensions/campaign-manager **/
+#crm-campaign-actions-list {
+  position: absolute;
+  display: block;
+  width: 256px;
+  left: 128;
+  z-index: 15;
+  -webkit-box-shadow:0 3px 18px 0 rgba(48,40,40,0.25);
+  box-shadow:0 3px 18px 0 rgba(48,40,40,0.25);
+  background:none;
+  border-radius:2px;
+  padding:0;top:36px
+}
+
+.crm-campaign-actions-list-inner {
+  background-color: #2f2f2e;
+  padding: 4px;
+}
+
+.crm-create-new-list-inner, .crm-create-new-list-inner ul {
+  width: 160px !important;
+}
+
+#crm-campaign-actions-list div[class*='-list-inner'] {
+  background:#fff;
+  border-radius:2px;
+  padding:0
+}
+
+#crm-campaign-actions-list div[class*='-list-inner'] li {
+  padding:0
+}
+
+#crm-campaign-actions-list div[class*='-list-inner'] li a {
+  color:#4d4d69;
+  font-size:13px;
+  line-height:18px;
+  padding:10px 20px
+}
+
+#crm-campaign-actions-list div[class*='-list-inner'] li a:hover {
+  background:#e8eef0
+}
+#campaign_container .crm-actions-ribbon {
+  margin-bottom: 20px !important;
+}
+
+#campaign_container #info {
+  margin: 0 !important;
+}
+
+#crm-campaign-actions-wrapper {
+  position: relative;
+  float: left;
+}

--- a/info.xml
+++ b/info.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<extension key="io.compuco.shoreditchthirdparty" type="module">
+  <file>shoreditchthirdparty</file>
+  <name>Shoreditch for third-party extensions</name>
+  <description>Provides Shoreditch compatibility fixes for third-party CiviCRM extensions</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>Compuco</author>
+    <email>hello@compuco.io</email>
+  </maintainer>
+  <urls>
+    <url desc="Documentation">https://github.com/compucorp/io.compuco.shoreditchthirdparty/README.md</url>
+  </urls>
+  <releaseDate>2022-09-07</releaseDate>
+  <version>1.0.0</version>
+  <develStage>alpha</develStage>
+  <compatibility>
+    <ver>5.39</ver>
+  </compatibility>
+  <requires>
+    <ext>org.civicrm.shoreditch</ext>
+  </requires>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <civix>
+    <namespace>CRM/Shoreditchthirdparty</namespace>
+    <angularModule>crmShoreditchthirdparty</angularModule>
+  </civix>
+</extension>

--- a/shoreditchthirdparty.civix.php
+++ b/shoreditchthirdparty.civix.php
@@ -1,0 +1,453 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Shoreditchthirdparty_ExtensionUtil {
+  const SHORT_NAME = 'shoreditchthirdparty';
+  const LONG_NAME = 'io.compuco.shoreditchthirdparty';
+  const CLASS_PREFIX = 'CRM_Shoreditchthirdparty';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Shoreditchthirdparty_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _shoreditchthirdparty_civix_civicrm_config(&$config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $template = CRM_Core_Smarty::singleton();
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $extDir = $extRoot . 'templates';
+
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
+  }
+
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_xmlMenu().
+ *
+ * @param $files array(string)
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
+ */
+function _shoreditchthirdparty_civix_civicrm_xmlMenu(&$files) {
+  foreach (_shoreditchthirdparty_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+    $files[] = $file;
+  }
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _shoreditchthirdparty_civix_civicrm_install() {
+  _shoreditchthirdparty_civix_civicrm_config();
+  if ($upgrader = _shoreditchthirdparty_civix_upgrader()) {
+    $upgrader->onInstall();
+  }
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _shoreditchthirdparty_civix_civicrm_postInstall() {
+  _shoreditchthirdparty_civix_civicrm_config();
+  if ($upgrader = _shoreditchthirdparty_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function _shoreditchthirdparty_civix_civicrm_uninstall() {
+  _shoreditchthirdparty_civix_civicrm_config();
+  if ($upgrader = _shoreditchthirdparty_civix_upgrader()) {
+    $upgrader->onUninstall();
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _shoreditchthirdparty_civix_civicrm_enable() {
+  _shoreditchthirdparty_civix_civicrm_config();
+  if ($upgrader = _shoreditchthirdparty_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
+ */
+function _shoreditchthirdparty_civix_civicrm_disable() {
+  _shoreditchthirdparty_civix_civicrm_config();
+  if ($upgrader = _shoreditchthirdparty_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_upgrade().
+ *
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
+ *
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function _shoreditchthirdparty_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  if ($upgrader = _shoreditchthirdparty_civix_upgrader()) {
+    return $upgrader->onUpgrade($op, $queue);
+  }
+}
+
+/**
+ * @return CRM_Shoreditchthirdparty_Upgrader
+ */
+function _shoreditchthirdparty_civix_upgrader() {
+  if (!file_exists(__DIR__ . '/CRM/Shoreditchthirdparty/Upgrader.php')) {
+    return NULL;
+  }
+  else {
+    return CRM_Shoreditchthirdparty_Upgrader_Base::instance();
+  }
+}
+
+/**
+ * Search directory tree for files which match a glob pattern.
+ *
+ * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
+ *
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
+ */
+function _shoreditchthirdparty_civix_find_files($dir, $pattern) {
+  return CRM_Utils_File::findFiles($dir, $pattern);
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_managed().
+ *
+ * Find any *.mgd.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
+ */
+function _shoreditchthirdparty_civix_civicrm_managed(&$entities) {
+  $mgdFiles = _shoreditchthirdparty_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
+  foreach ($mgdFiles as $file) {
+    $es = include $file;
+    foreach ($es as $e) {
+      if (empty($e['module'])) {
+        $e['module'] = E::LONG_NAME;
+      }
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
+      $entities[] = $e;
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_caseTypes().
+ *
+ * Find any and return any files matching "xml/case/*.xml"
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
+ */
+function _shoreditchthirdparty_civix_civicrm_caseTypes(&$caseTypes) {
+  if (!is_dir(__DIR__ . '/xml/case')) {
+    return;
+  }
+
+  foreach (_shoreditchthirdparty_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    $name = preg_replace('/\.xml$/', '', basename($file));
+    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+      throw new CRM_Core_Exception($errorMessage);
+    }
+    $caseTypes[$name] = [
+      'module' => E::LONG_NAME,
+      'name' => $name,
+      'file' => $file,
+    ];
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function _shoreditchthirdparty_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _shoreditchthirdparty_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = E::LONG_NAME;
+    }
+    $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _shoreditchthirdparty_civix_civicrm_themes(&$themes) {
+  $files = _shoreditchthirdparty_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
+ * Glob wrapper which is guaranteed to return an array.
+ *
+ * The documentation for glob() says, "On some systems it is impossible to
+ * distinguish between empty match and an error." Anecdotally, the return
+ * result for an empty match is sometimes array() and sometimes FALSE.
+ * This wrapper provides consistency.
+ *
+ * @link http://php.net/glob
+ * @param string $pattern
+ *
+ * @return array
+ */
+function _shoreditchthirdparty_civix_glob($pattern) {
+  $result = glob($pattern);
+  return is_array($result) ? $result : [];
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _shoreditchthirdparty_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label'      => CRM_Utils_Array::value('name', $item),
+        'active'     => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _shoreditchthirdparty_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _shoreditchthirdparty_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _shoreditchthirdparty_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _shoreditchthirdparty_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _shoreditchthirdparty_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _shoreditchthirdparty_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _shoreditchthirdparty_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
+ */
+function _shoreditchthirdparty_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+    $metaDataFolders[] = $settingsDir;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _shoreditchthirdparty_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
+}

--- a/shoreditchthirdparty.php
+++ b/shoreditchthirdparty.php
@@ -1,0 +1,144 @@
+<?php
+
+require_once 'shoreditchthirdparty.civix.php';
+// phpcs:disable
+use CRM_Shoreditchthirdparty_ExtensionUtil as E;
+// phpcs:enable
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
+ */
+function shoreditchthirdparty_civicrm_config(&$config) {
+  _shoreditchthirdparty_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_xmlMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
+ */
+function shoreditchthirdparty_civicrm_xmlMenu(&$files) {
+  _shoreditchthirdparty_civix_civicrm_xmlMenu($files);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function shoreditchthirdparty_civicrm_install() {
+  _shoreditchthirdparty_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function shoreditchthirdparty_civicrm_postInstall() {
+  _shoreditchthirdparty_civix_civicrm_postInstall();
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+ */
+function shoreditchthirdparty_civicrm_uninstall() {
+  _shoreditchthirdparty_civix_civicrm_uninstall();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function shoreditchthirdparty_civicrm_enable() {
+  _shoreditchthirdparty_civix_civicrm_enable();
+}
+
+/**
+ * Implements hook_civicrm_disable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ */
+function shoreditchthirdparty_civicrm_disable() {
+  _shoreditchthirdparty_civix_civicrm_disable();
+}
+
+/**
+ * Implements hook_civicrm_upgrade().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
+ */
+function shoreditchthirdparty_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
+  return _shoreditchthirdparty_civix_civicrm_upgrade($op, $queue);
+}
+
+/**
+ * Implements hook_civicrm_managed().
+ *
+ * Generate a list of entities to create/deactivate/delete when this module
+ * is installed, disabled, uninstalled.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
+ */
+function shoreditchthirdparty_civicrm_managed(&$entities) {
+  _shoreditchthirdparty_civix_civicrm_managed($entities);
+}
+
+/**
+ * Implements hook_civicrm_caseTypes().
+ *
+ * Add CiviCase types provided by this extension.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
+ */
+function shoreditchthirdparty_civicrm_caseTypes(&$caseTypes) {
+  _shoreditchthirdparty_civix_civicrm_caseTypes($caseTypes);
+}
+
+/**
+ * Implements hook_civicrm_angularModules().
+ *
+ * Add Angular modules provided by this extension.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function shoreditchthirdparty_civicrm_angularModules(&$angularModules) {
+  // Auto-add module files from ./ang/*.ang.php
+  _shoreditchthirdparty_civix_civicrm_angularModules($angularModules);
+}
+
+/**
+ * Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
+ */
+function shoreditchthirdparty_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  _shoreditchthirdparty_civix_civicrm_alterSettingsFolders($metaDataFolders);
+}
+
+/**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * Declare entity types provided by this module.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function shoreditchthirdparty_civicrm_entityTypes(&$entityTypes) {
+  _shoreditchthirdparty_civix_civicrm_entityTypes($entityTypes);
+}
+
+/**
+ * Implements hook_civicrm_themes().
+ */
+function shoreditchthirdparty_civicrm_themes(&$themes) {
+  _shoreditchthirdparty_civix_civicrm_themes($themes);
+}
+
+function shoreditchthirdparty_civicrm_coreResourceList(&$list, $region) {
+  CRM_Core_Resources::singleton()->addStyleFile('io.compuco.shoreditchthirdparty', 'css/shoreditchforthirdparty.css', 1000, 'html-header');
+}


### PR DESCRIPTION
## Overview

Fixing Shoreditch compatibility issues with 'Campaign Manger' extension.

## Before

There is a large distance between the campaign action buttons and the campaign information, also when clicking on the "Actions" button it appears away from the button itself and still has the old Civi style.

![image](https://user-images.githubusercontent.com/6275540/188915444-f2f4c8de-a3cf-4876-879b-2b10db9dd15e.png)


## After
All the issues above are resolved:
![dsadsadsa](https://user-images.githubusercontent.com/6275540/188916159-e68fc504-8d50-4fc0-9a35-a6c022a42cf7.gif)


## Technical Details

We are planning to add new third party extension to Compuclient called  'Campaign Manger' (https://civicrm.org/extensions/campaign-manager) , but as mentioned in the Before section above, there are few UI issues. Given that:

1- We don't own the extension, thus trying to send any kind of fixes to the maintainers might take time to get approved and merged (if it even happened) .

2- Such fixes anyway would be Shoreditch specific, but the extension itself is not given its maintainers did not design it for Shoreditch, thus trying to push such kind of fixes will for sure get rejected.

3- If we instead fork the extension and apply such fixes to it, then we have to maintain such fork and keep it updated with the main version, which is a hassle.

Thus I decided to create this extension, the idea of it is to be used for any kind of  Shoreditch compatibility fixes needed for 3rd party extensions that we have or plan to add in Compuclient.

The idea of this extension is simple, it is just add a new CSS file to all civicrm page (given that Shoreditch custom-civicrm.css is added to all pages by default anyway), and this file will contain any compatibility fixes needed for any 3rd party extension. If JS fixes also needed in the future, a JS file can be added too.

